### PR TITLE
Network Cloudformation touch ups.

### DIFF
--- a/network/template.yml
+++ b/network/template.yml
@@ -116,7 +116,7 @@ Resources:
     Type: AWS::EC2::FlowLog
     Properties:
       DeliverLogsPermissionArn : !GetAtt FlowLogRole.Arn
-      LogGroupName : CloudWatchLogGroup
+      LogGroupName : !Ref CloudWatchLogGroup
       ResourceId : !Ref VPC
       ResourceType : VPC
       TrafficType : ALL
@@ -516,19 +516,19 @@ Resources:
     Type: AWS::EC2::NatGateway
     Properties:
       AllocationId: !GetAtt NatGateway1EIP.AllocationId
-      SubnetId: !Ref AppSubnet1
+      SubnetId: !Ref PublicSubnet1
 
   NatGateway2:
     Type: AWS::EC2::NatGateway
     Properties:
       AllocationId: !GetAtt NatGateway2EIP.AllocationId
-      SubnetId: !Ref AppSubnet3
+      SubnetId: !Ref PublicSubnet2
 
   NatGateway3:
     Type: AWS::EC2::NatGateway
     Properties:
       AllocationId: !GetAtt NatGateway3EIP.AllocationId
-      SubnetId: !Ref AppSubnet3
+      SubnetId: !Ref PublicSubnet3
 
   PublicRouteTable:
     Type: AWS::EC2::RouteTable


### PR DESCRIPTION
Update NAT subnets to be the public subnets so that traffic can be routed to the internet. Get the log group name from the CloudWatchLogGroup via a reference.