### PR TITLE
Adding iam role to cluster stack

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ export AWS_DEFAULT_REGION := $(REGION)
 .PHONY: buildStack deleteStack help test-scripts
 
 help:
-	@echo "make buildStack STACK_NAME=<stackName> CFN_LOCATION=<Cloudformation template location> CFN_PARAMS=<Parameters json file location> DEFAULTREGION=aws_region (optional if region=ap-souteast-2"
+	@echo "make buildStack STACK_NAME=<stackName> CFN_LOCATION=<Cloudformation template location> CFN_PARAMS=<Parameters json file location> DEFAULTREGION=aws_region (optional if region=ap-souteast-2)"
 
 buildStack:
 	./scripts/deploy_stack.sh $(STACK_NAME) $(STACK_TEMPLATE_FILE) $(STACK_PARAMS_FILE)

--- a/ecs-cluster/params.json
+++ b/ecs-cluster/params.json
@@ -13,11 +13,11 @@
   },
   {
     "ParameterKey": "VpcId",
-    "ParameterValue": "vpc-640cb600"
+    "ParameterValue": "vpc-8fd14ceb"
   },
   {
     "ParameterKey": "PrivateSubnets",
-    "ParameterValue": "subnet-5320a70a"
+    "ParameterValue": "subnet-619ec705,subnet-c4ffb2b2,subnet-49eb7d10"
   },
   {
     "ParameterKey": "EcsAMI",

--- a/ecs-cluster/template.yml
+++ b/ecs-cluster/template.yml
@@ -1,11 +1,7 @@
 AWSTemplateFormatVersion: 2010-09-09
-Description: Provides shared ECS cluster to be used by a tribe.
+Description: Provides shared ECS cluster to be used by a team.
 
 Parameters:
-  InstanceRole:
-    Type: String
-    Description: The IAM instance role to be used.
-    Default: ops-poc-ecs
   InstanceType:
     Type: String
     Description: The EC2 instance type to host Docker.
@@ -39,12 +35,32 @@ Parameters:
     Default: 1
 
 Resources:
-  InstanceProfile:
+  EC2Role:
+    Type: AWS::IAM::Role
+    Properties:
+      AssumeRolePolicyDocument:
+        Statement:
+        - Effect: Allow
+          Principal:
+            Service: [ec2.amazonaws.com]
+          Action: ['sts:AssumeRole']
+      Path: /
+      Policies:
+      - PolicyName: ecs-service
+        PolicyDocument:
+          Statement:
+          - Effect: Allow
+            Action: ['ecs:CreateCluster', 'ecs:DeregisterContainerInstance', 'ecs:DiscoverPollEndpoint',
+              'ecs:Poll', 'ecs:RegisterContainerInstance', 'ecs:StartTelemetrySession',
+              'ecs:Submit*', 'logs:CreateLogStream', 'logs:PutLogEvents']
+            Resource: '*'
+
+  Ec2InstanceProfile:
     Type: AWS::IAM::InstanceProfile
     Properties:
       Path: /
       Roles:
-      - !Ref InstanceRole
+      - !Ref EC2Role
 
   ECSCluster:
     Type: AWS::ECS::Cluster
@@ -59,7 +75,7 @@ Resources:
     Properties:
       ImageId: !Ref EcsAMI
       InstanceType: !Ref InstanceType
-      IamInstanceProfile: !Ref InstanceProfile
+      IamInstanceProfile: !Ref Ec2InstanceProfile
       KeyName: !Ref SSHKeyName
       AssociatePublicIpAddress: True
       SecurityGroups:

--- a/scripts/deploy_stack.sh
+++ b/scripts/deploy_stack.sh
@@ -85,11 +85,11 @@ stack_ctl() {
     local action="$1"
     log "name=$stack_name action=$action"
 
-    aws cloudformation "$action" \
+    aws cloudformation $action \
         --capabilities CAPABILITY_IAM CAPABILITY_NAMED_IAM \
         --stack-name "$stack_name" \
-        --template-body file://"$stack_tmpl" \
-        --parameters file://"$stack_params" >/dev/null
+        --template-body "file://$stack_tmpl" \
+        --parameters "file://$stack_params" > /dev/null
 
     wait_completion "$stack_name" || return 1
 }


### PR DESCRIPTION
- Instead of passing a role name as a parameter, create a new one and use a more proper name (ec2-role). Other roles will be added to the application stack.
- some tweaks to the shell script so it does not complain.