### PR TITLE
Update the subnet ranges to match netmask boundaries

### DIFF
--- a/network/params.json
+++ b/network/params.json
@@ -13,11 +13,11 @@
   },
   {
     "ParameterKey": "AppSubnetCIDR",
-    "ParameterValue": "192.168.100.0/20,192.168.116.0/20,192.168.132.0/20"
+    "ParameterValue": "192.168.64.0/20,192.168.80.0/20,192.168.96.0/20"
   },
   {
     "ParameterKey": "DataSubnetCIDR",
-    "ParameterValue": "192.168.200.0/20,192.168.216.0/20,192.168.232.0/20"
+    "ParameterValue": "192.168.128.0/20,192.168.144.0/20,192.168.160.0/20"
   },
   {
     "ParameterKey": "VpcFlowLogRetention",


### PR DESCRIPTION
This PR changes the subnet boundaries to match a `/18` netmask.