### PR TITLE
remove duplicate target; update help to use P_REGION var [skip ci]

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -63,17 +63,13 @@ delete-test:
 	aws cloudformation wait stack-delete-complete --stack-name $(STACKNET) && \
 	echo "--- :trophy: Test stack deleted!"
 
-test-scripts:
-	@echo '--- :bash: Testing scripts'
-	docker run -v "$(PWD):/mnt" koalaman/shellcheck scripts/*.sh
-
 help:
 	@echo ''
 	@echo '-------------------------------------------------------'
 	@echo "Orlando's Amazing Stack Buildy Thing!"
 	@echo '-------------------------------------------------------'
 	@echo ''
-	@echo 'To execute against ap-southeast-2: make stack'
+	@echo 'To execute against $(P_REGION): make stack'
 	@echo ''
 	@echo 'The templates that will be submitted for execution are:'
 	@echo 'network/template.yml'


### PR DESCRIPTION
Somehow there were two `test-scripts` targets in the Makefile. I also changed the region (production) in the Makefile help to reference the variable P_REGION.